### PR TITLE
docs: update steps for service installation with NSSM

### DIFF
--- a/docs/getting-started/buildfromsource.mdx
+++ b/docs/getting-started/buildfromsource.mdx
@@ -255,7 +255,8 @@ To run jellyseerr as a service:
 1. Download the [Non-Sucking Service Manager](https://nssm.cc/download)
 2. Install NSSM:
 ```powershell
-nssm install Jellyseerr "C:\Program Files\nodejs\node.exe" ["C:\jellyseerr\dist\index.js"]
+nssm install Jellyseerr "C:\Program Files\nodejs\node.exe" "C:\jellyseerr\dist\index.js"
+nssm set Jellyseerr AppDirectory "C:\jellyseerr"
 nssm set Jellyseerr AppEnvironmentExtra NODE_ENV=production
 ```
 3. Start the service:


### PR DESCRIPTION
#### Description
The current steps for installing Jellyseerr as a service with NSSM do not work, since the 'AppDirectory' parameter defaults to the Node.js directory. The [] brackets have to be removed as well.